### PR TITLE
Hook mozilla repo for 'ssplit-cpp' submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/mozilla/marian-dev
 [submodule "3rd_party/ssplit-cpp"]
 	path = 3rd_party/ssplit-cpp
-	url = http://github.com/ugermann/ssplit-cpp
+	url = http://github.com/mozilla/ssplit-cpp
 [submodule "3rd_party/crow"]
 	path = 3rd_party/crow
 	url = https://github.com/ipkn/crow


### PR DESCRIPTION
- used 7b8a89fe59513467ec2894791cef69793ae9a91c commit
  from master branch of mozilla/ssplit-cpp repo